### PR TITLE
feat: 启动时检查是否存在更新 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,14 @@ name = "MaaDebugger"
 version = "v0.0.1"
 description = "MaaDebugger"
 authors = [{ name = "MaaXYZ" }]
-dependencies = ["MaaFw>=4.0.0b2", "nicegui>=2.2.0", "asyncify", "pillow"]
+dependencies = [
+    "MaaFw>=4.0.0b2",
+    "nicegui>=2.2.0",
+    "asyncify",
+    "pillow",
+    "packaging",
+    "semver",
+]
 readme = "README.md"
 urls = { Homepage = "https://github.com/MaaXYZ/MaaDebugger" }
 requires-python = ">=3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ maafw>=4.0.0b2
 nicegui>=2.2.0
 asyncify
 pillow
+packaging
+semver

--- a/src/MaaDebugger/utils/update_checker/__init__.py
+++ b/src/MaaDebugger/utils/update_checker/__init__.py
@@ -37,7 +37,7 @@ async def get_pypi() -> Optional[str]:  # -> '1.8.0b1'
 
 
 def compare_tag_name(tag_name: str) -> bool:
-    if semver.compare(tag_name.lstrip("v"), __version__.tag_name.lstrip("v")) == 1:
+    if semver.compare(tag_name, __version__.tag_name.lstrip("v")) == 1:
         return True
     else:
         return False
@@ -69,8 +69,8 @@ async def check_update() -> Union[ChcekStatus, str, None]:  # PyPi -> Github -> 
             return None
 
     if github := await get_github():
-        if compare_tag_name(github):
-            return str(parse_version(github))
+        if compare_tag_name(github.lstrip("v")):
+            return str(parse_version(github.lstrip("v")))
         else:
             return None
 

--- a/src/MaaDebugger/utils/update_checker/__init__.py
+++ b/src/MaaDebugger/utils/update_checker/__init__.py
@@ -1,0 +1,77 @@
+from enum import auto, Enum
+from typing import Optional, Union
+
+import httpx
+import semver
+from packaging.version import parse as parse_version
+
+from ... import __version__
+
+GITHUB_API = "https://api.github.com/repos/MaaXYZ/MaaDebugger/releases/latest"
+PYPI_API = "https://pypi.org/pypi/MaaDebugger/json"
+
+
+class ChcekStatus(Enum):
+    FAILED = auto()
+    SKIPPED = auto()
+
+
+async def get_github() -> Optional[str]:  # -> 'v1.8.0-beta.1'
+    try:
+        async with httpx.AsyncClient() as client:
+            req = await client.get(GITHUB_API, timeout=5)
+            if req.status_code == 200:
+                return req.json().get("tag_name")
+    except Exception as e:
+        print(f"WARNING: Failed to GET Github API", e)
+
+
+async def get_pypi() -> Optional[str]:  # -> '1.8.0b1'
+    try:
+        async with httpx.AsyncClient() as client:
+            req = await client.get(PYPI_API, timeout=5)
+            if req.status_code == 200:
+                return req.json().get("info", {}).get("version")
+    except Exception as e:
+        print(f"WARNING: Failed to GET PyPi API", e)
+
+
+def compare_tag_name(tag_name: str) -> bool:
+    if semver.compare(tag_name, __version__.tag_name) == 1:
+        return True
+    else:
+        return False
+
+
+def compare_version(version: str) -> bool:
+    remote_ver = parse_version(version)
+    current_ver = parse_version(__version__.version)
+
+    if remote_ver > current_ver:
+        return True
+    else:
+        return False
+
+
+async def check_update() -> Union[ChcekStatus, str, None]:  # PyPi -> Github -> FAILED
+    """
+    If updatable, return a version str (like 1.8.0b1); else return None\n
+    If checking was skipped, return 'SKIPPED'\n
+    If checking is failed, return 'FAILED'
+    """
+    if __version__.version == "DEBUG" or __version__.tag_name == "DEBUG":
+        return ChcekStatus.SKIPPED
+
+    if pypi := await get_pypi():
+        if compare_version(pypi):
+            return pypi
+        else:
+            return None
+
+    if github := await get_github():
+        if compare_tag_name(github):
+            return str(parse_version(github))
+        else:
+            return None
+
+    return ChcekStatus.FAILED

--- a/src/MaaDebugger/utils/update_checker/__init__.py
+++ b/src/MaaDebugger/utils/update_checker/__init__.py
@@ -18,7 +18,7 @@ class ChcekStatus(Enum):
 
 async def get_github() -> Optional[str]:  # -> 'v1.8.0-beta.1'
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(trust_env=False) as client:
             req = await client.get(GITHUB_API, timeout=5)
             if req.status_code == 200:
                 return req.json().get("tag_name")
@@ -28,7 +28,7 @@ async def get_github() -> Optional[str]:  # -> 'v1.8.0-beta.1'
 
 async def get_pypi() -> Optional[str]:  # -> '1.8.0b1'
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(trust_env=False) as client:
             req = await client.get(PYPI_API, timeout=5)
             if req.status_code == 200:
                 return req.json().get("info", {}).get("version")
@@ -37,7 +37,7 @@ async def get_pypi() -> Optional[str]:  # -> '1.8.0b1'
 
 
 def compare_tag_name(tag_name: str) -> bool:
-    if semver.compare(tag_name, __version__.tag_name) == 1:
+    if semver.compare(tag_name.lstrip("v"), __version__.tag_name.lstrip("v")) == 1:
         return True
     else:
         return False

--- a/src/MaaDebugger/webpage/index_page/__init__.py
+++ b/src/MaaDebugger/webpage/index_page/__init__.py
@@ -1,15 +1,13 @@
 from nicegui import ui
 
-from .master_control import check_update
 from .master_control import main as master_control
 from .runtime_control import main as runtime_control
 
 
 def index():
+
     master_control()
 
     ui.separator()
 
     runtime_control()
-
-    ui.timer(3, check_update, once=True)  # Make sure the timer is added last

--- a/src/MaaDebugger/webpage/index_page/__init__.py
+++ b/src/MaaDebugger/webpage/index_page/__init__.py
@@ -1,5 +1,6 @@
 from nicegui import ui
 
+from .master_control import check_update
 from .master_control import main as master_control
 from .runtime_control import main as runtime_control
 
@@ -10,3 +11,5 @@ def index():
     ui.separator()
 
     runtime_control()
+
+    ui.timer(3, check_update, once=True)  # Make sure the timer is added last

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -24,6 +24,8 @@ class GlobalStatus:
 
 
 def main():
+    app.on_startup(check_update)
+
     with ui.row():
         with ui.column():
             connect_control()

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -7,6 +7,7 @@ from nicegui import app, binding, ui
 
 from ...maafw import maafw
 from ...utils import input_checker as ic
+from ...utils import update_checker
 from ...webpage.components.status_indicator import Status, StatusIndicator
 from . import notify
 
@@ -436,3 +437,16 @@ def run_task_control():
 
         GlobalStatus.task_running = Status.PENDING
         await maafw.screenshotter.refresh(True)
+
+
+async def check_update():
+    status = await update_checker.check_update()
+
+    if status == update_checker.ChcekStatus.SKIPPED or status is None:
+        return
+    elif status == update_checker.ChcekStatus.FAILED:
+        notify.send("Failed to check for updates", type="warning", with_print=True)
+    elif status:
+        notify.send(
+            f"New version available: {status}", type="positive", with_print=True
+        )

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -447,8 +447,20 @@ async def check_update():
     if status == update_checker.ChcekStatus.SKIPPED or status is None:
         return
     elif status == update_checker.ChcekStatus.FAILED:
-        notify.send("Failed to check for updates", type="warning", with_print=True)
-    elif status:
-        notify.send(
-            f"New version available: {status}", type="positive", with_print=True
+        ui.notification(
+            "Failed to check for updates",
+            type="warning",
+            position="bottom-right",
+            close_button=True,
+            timeout=10,
         )
+        print("Failed to check for updates")
+    elif status:
+        ui.notification(
+            f"New version available: {status}",
+            type="positive",
+            position="bottom-right",
+            close_button=True,
+            timeout=10,
+        )
+        print(f"New version available: {status}")

--- a/tools/pip_pack.py
+++ b/tools/pip_pack.py
@@ -26,6 +26,9 @@ def set_python_ver():
     ver = str(parse_version(tag_name))
 
     with open(VER_FILE, "w", encoding="utf-8") as f:
+        f.write(
+            f'# If you wish to disable checking for updates on startup, you can change any of the following values to "DEBUG"\n# For example, version = "DEBUG"\n\n'
+        )
         f.write(f'version = "{ver}"\n')
         f.write(f'tag_name = "{tag_name}"\n')
 


### PR DESCRIPTION
#36 

已知问题：
- [x] 连接代理时必定引发 `httpcore.ConnectTimeout` 导致检查失败
> 通过 `trust_env = False` 禁用代理后表现正常，暂不清楚是否存在其他隐患