### PR TITLE
feat: add debug page

### DIFF
--- a/src/MaaDebugger/maafw/__init__.py
+++ b/src/MaaDebugger/maafw/__init__.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Optional, Tuple, Union
 
 from asyncify import asyncify
 from PIL import Image
+from maa.library import Library
 from maa.controller import AdbController, Win32Controller
 from maa.tasker import Tasker, RecognitionDetail, NotificationHandler
 from maa.resource import Resource
@@ -34,6 +35,10 @@ class MaaFW:
 
         self.screenshotter = Screenshotter(self.screencap)
         self.notification_handler = None
+
+    @property
+    def version(self) -> str:
+        return Library.version()
 
     @staticmethod
     @asyncify

--- a/src/MaaDebugger/utils/infos/__init__.py
+++ b/src/MaaDebugger/utils/infos/__init__.py
@@ -1,0 +1,25 @@
+import sys
+import platform
+from pathlib import Path
+
+import nicegui
+import packaging
+import packaging.version
+
+from ...maafw import maafw
+from ... import __version__
+
+
+class Infos:
+    CWD = Path.cwd()
+    DEBUG_DIR = CWD / "debug"
+    OS_TYPE = platform.system()
+    OS_VERSION = platform.version()
+    OS_INFO = f"{OS_TYPE} {OS_VERSION}"
+    MACHINE = platform.machine()
+    PYTHON_VERSION = (
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    )
+    DBG_VERSION = __version__.version
+    MAAFW_VERSION = str(packaging.version.parse(maafw.version))
+    NICEGUI_VERSION = nicegui.__version__

--- a/src/MaaDebugger/webpage/debug_page/__init__.py
+++ b/src/MaaDebugger/webpage/debug_page/__init__.py
@@ -1,0 +1,149 @@
+import json
+from pathlib import Path
+from typing import Literal
+
+from nicegui import ui
+
+from ..traceback_page import TracebackData
+from ...maafw import maafw
+from ...utils.infos import Infos
+
+
+def export_maafw_log():
+    log_path = Path.cwd() / "debug/maa.log"
+    if not log_path.exists():
+        ui.notify(
+            f"{log_path} does not exist.", position="bottom-right", type="warning"
+        )
+        return
+    ui.download(log_path, "maa.log")
+
+
+async def clear_maafw_cache():
+    if await maafw.clear_cache():
+        ui.notify("Cleared.", position="bottom-right", type="info")
+
+
+def export_traceback_data():
+    data = json.dumps(TracebackData.data, indent=4, ensure_ascii=False).encode()
+    ui.download(data, "traceback_data.json")
+
+
+def copy_data(data: str):
+    ui.clipboard.write(data)
+    ui.notify("Copied.", position="bottom-right", type="info")
+
+
+def save_data(
+    type: Literal["yaml", "json", "markdown"],
+    mode: Literal["copy", "download"],
+    elements: tuple[ui.input],
+):
+    data = ""
+    if type == "yaml":
+        for e in elements:
+            data += f"{e.props['label']}: {e.value}\n"
+    elif type == "json":
+        for e in elements:
+            _data = {e.props["label"]: e.value for e in elements}
+        data = json.dumps(_data, indent=4, ensure_ascii=False)
+    elif type == "markdown":
+        for e in elements:
+            data += f"#### {e.props['label']}\n{e.value}\n\n"
+
+    if mode == "copy":
+        copy_data(data)
+    elif mode == "download":
+        ui.download(data.encode(), f"infos.{type}")
+
+
+def create_info_dialog() -> ui.dialog:
+    dialog = ui.dialog()
+    with dialog, ui.card():
+        ui.markdown("#### Infos")
+        ui.separator()
+
+        with ui.row().classes("w-full"):
+            cwd = ui.input("CWD").bind_value_from(
+                Infos, "CWD", backward=lambda x: str(x)
+            )
+            debug_dir = ui.input("Debug Directory").bind_value_from(
+                Infos, "DEBUG_DIR", backward=lambda x: str(x)
+            )
+        with ui.row().classes("w-full"):  # OS infos
+            os_info = ui.input("OS Info").bind_value_from(Infos, "OS_INFO")
+            machine = ui.input("Machine").bind_value_from(Infos, "MACHINE")
+        with ui.row().classes("w-full"):
+            py_ver = ui.input("Python Version").bind_value_from(Infos, "PYTHON_VERSION")
+            dbg_ver = ui.input("Debugger Version").bind_value_from(Infos, "DBG_VERSION")
+        with ui.row():  # deps version
+            fw_ver = ui.input("MaaFW Version").bind_value_from(Infos, "MAAFW_VERSION")
+            nice_ver = ui.input("NiceGUI Version").bind_value_from(
+                Infos, "NICEGUI_VERSION"
+            )
+
+        elements = (cwd, debug_dir, os_info, machine, py_ver, dbg_ver, fw_ver, nice_ver)
+        for e in elements:
+            e.on("click", lambda e=e: copy_data(e.value))  # type: ignore
+
+        with ui.row(align_items="center").classes("justify-center").classes("w-full"):
+            with ui.dropdown_button(
+                "Copy",
+                split=True,
+                on_click=lambda e=elements: save_data("json", "copy", e),  # type: ignore
+            ).props("no-caps"):
+                ui.item(
+                    "Copy as Yaml",
+                    on_click=lambda e=elements: save_data("yaml", "copy", e),  # type: ignore
+                ).props("no-caps")
+                ui.item(
+                    "Copy as Markdown",
+                    on_click=lambda e=elements: save_data("markdown", "copy", e),  # type: ignore
+                ).props("no-caps")
+            with ui.dropdown_button(
+                "Export",
+                split=True,
+                on_click=lambda e=elements: save_data("json", "download", e),  # type: ignore
+            ).props("no-caps"):
+                ui.item(
+                    "Export as Yaml",
+                    on_click=lambda e=elements: save_data("yaml", "download", e),  # type: ignore
+                ).props("no-caps")
+                ui.item(
+                    "Export as Markdown",
+                    on_click=lambda e=elements: save_data("markdown", "download", e),  # type: ignore
+                ).props("no-caps")
+
+    return dialog
+
+
+@ui.page("/debug")
+def create_debug_page():
+    ui.page_title("Debug")
+    ui.markdown("## Debug Page")
+    ui.separator()
+
+    info_dialog = create_info_dialog()
+
+    with ui.card().classes("w-full"):
+        ui.markdown("#### MaaFramework")
+        with ui.row():
+            ui.button("Export Log", on_click=export_maafw_log).props("no-caps")
+            ui.button("Clear Cache", on_click=clear_maafw_cache).props("no-caps")
+
+    with ui.card().classes("w-full"):
+        ui.markdown("#### Feature Test")
+        with ui.row():
+            with ui.dropdown_button("Raise Error").props("no-caps"):
+                ui.item("Raise Json Error", on_click=lambda: json.loads("{")).props(
+                    "no-caps"
+                )
+                ui.item("Raise Path Error", on_click=lambda: Path(None)).props("no-caps")  # type: ignore
+            ui.button("Export Traceback Data", on_click=export_traceback_data).props(
+                "no-caps"
+            )
+
+    with ui.card().classes("w-full"):
+        ui.markdown("#### Others")
+        with ui.row():
+            ui.button("Info", on_click=info_dialog.open).props("no-caps")

--- a/src/MaaDebugger/webpage/debug_page/__init__.py
+++ b/src/MaaDebugger/webpage/debug_page/__init__.py
@@ -9,6 +9,10 @@ from ...maafw import maafw
 from ...utils.infos import Infos
 
 
+class DebugData:
+    auto_clear_maafw_cache: bool = True
+
+
 def export_maafw_log():
     log_path = Path.cwd() / "debug/maa.log"
     if not log_path.exists():
@@ -130,6 +134,9 @@ def create_debug_page():
         with ui.row():
             ui.button("Export Log", on_click=export_maafw_log).props("no-caps")
             ui.button("Clear Cache", on_click=clear_maafw_cache).props("no-caps")
+            ui.switch("Auto Clear Cache").bind_value(
+                DebugData, "auto_clear_maafw_cache"
+            )
 
     with ui.card().classes("w-full"):
         ui.markdown("#### Feature Test")

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -11,6 +11,7 @@ from ...utils import update_checker
 from ...webpage.components.status_indicator import Status, StatusIndicator
 from ..traceback_page import on_exception
 from . import notify
+from .. import debug_page
 
 binding.MAX_PROPAGATION_TIME = 1
 STORAGE = app.storage.general

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -11,7 +11,7 @@ from ...utils import update_checker
 from ...webpage.components.status_indicator import Status, StatusIndicator
 from ..traceback_page import on_exception
 from . import notify
-from .. import debug_page
+from ..debug_page import DebugData
 
 binding.MAX_PROPAGATION_TIME = 1
 STORAGE = app.storage.general
@@ -408,7 +408,8 @@ def run_task_control():
         ui.button("Stop", on_click=lambda: on_click_stop())
 
     async def on_click_start():
-        await maafw.clear_cache()
+        if DebugData.auto_clear_maafw_cache:
+            await maafw.clear_cache()
 
         GlobalStatus.task_running = Status.RUNNING
 

--- a/src/MaaDebugger/webpage/traceback_page/__init__.py
+++ b/src/MaaDebugger/webpage/traceback_page/__init__.py
@@ -67,6 +67,7 @@ def creata_traceback_all_page():
 
     ui.page_title("Tracebacks")
     ui.markdown("## Tracebacks")
+
     with ui.row(align_items="center").classes("w-full"):
         ui.number("Maximum Results to Show", min=1).bind_value(
             TracebackData, "max_display"


### PR DESCRIPTION
访问 `[address]/debug` 以访问 debug 页面

我不确定这是不是一个 feat, 也不确定是否有必要给 dbg 写一个 debug 页面
设想中，开发者可以在 /debug 中测试新功能，并且在问题发生时可以指导用户进行简单的测试（或许可以吧
基于 NiceGUI 的特性， page 在访问时才被构建，对性能不会有显著影响

这个 PR 还没有完成：
- [ ] 是否有必要加入 debug page ？
- [ ] 能为 debug page 添加什么功能？

现阶段的 debug page 长这样（3.25）：
![image](https://github.com/user-attachments/assets/edd33e62-baf3-4b26-8d29-2f94f68e55ae)
