### PR TITLE
feat: 支持设置 NiceGUI `language` 启动参数

### DIFF
--- a/src/MaaDebugger/main.py
+++ b/src/MaaDebugger/main.py
@@ -14,6 +14,7 @@ def main():
     port = args.get_port() or 8011
     show = args.get_hide()
     dark = args.get_dark()
+    lang = args.get_language()
 
     index_page.index()
 
@@ -26,5 +27,6 @@ def main():
         show=show,
         dark=dark,
         favicon=Path(__file__).parent / "maa.ico",
+        language=lang,  # type:ignore
         # root_path="/proxy/8011",
     )

--- a/src/MaaDebugger/utils/arg_parser/__init__.py
+++ b/src/MaaDebugger/utils/arg_parser/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import locale
 from typing import Optional
 
 
@@ -34,6 +35,12 @@ class ArgParser:
             action="store_true",
             help="DON'T automatically open the UI in a browser tab. (Default: False)",
             default=False,
+        )
+        self.parser.add_argument(
+            "--language",
+            "--lang",
+            help="The language for Quasar elements (default: {System} or 'en-US')",
+            default=None,
         )
 
     def _add_dark_group(self):
@@ -95,3 +102,16 @@ class ArgParser:
             return False
         else:
             return None
+
+    def get_language(self) -> str:
+        args_lang: Optional[str] = self.args.language
+        if args_lang:
+            args_lang = args_lang.replace("_", "-")
+
+        system_lang, _ = locale.getlocale()
+        if system_lang:
+            system_lang = system_lang.replace("_", "-")
+        else:
+            system_lang = None
+
+        return args_lang or system_lang or "en-US"


### PR DESCRIPTION
最直观（很有可能也是唯一的）效果是左下角的连接丢失可以以设置语言显示。
这是 NiceGUI 的依赖组件库 Quasar 的原生国际化。
![image](https://github.com/user-attachments/assets/e9ed695a-de7e-4c8d-a50d-aebfdd0203b9)

即便用户传入一个错误的值（比如 114514 之类的），也会正常用英文继续启动，不会遇到异常。
设置优先级是 传入参数 > 系统默认 > en-US

NiceGUI 要求的格式是 zh-CN 而不是 zh_CN ，因此我 replace 了所有的下划线。

~~从目前来看，这其实是一个没什么用的 feat~~
但既然它可以实现，不如就先实现了。也许以后社区会长出国际化也说不定（？