### PR TITLE
fix: 临时禁用检查更新以修复启动缓慢的问题

### DIFF
--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -26,7 +26,6 @@ class GlobalStatus:
 def main():
     app.on_exception(on_exception)
     # app.on_startup(check_update)
-    # Waiting for testing further.
 
     with ui.row():
         with ui.column():

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -25,7 +25,8 @@ class GlobalStatus:
 
 def main():
     app.on_exception(on_exception)
-    app.on_startup(check_update)
+    # app.on_startup(check_update)
+    # Waiting for testing further.
 
     with ui.row():
         with ui.column():

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -26,6 +26,7 @@ class GlobalStatus:
 def main():
     app.on_exception(on_exception)
     # app.on_startup(check_update)
+    # Waiting for fix. https://github.com/MaaXYZ/MaaDebugger/pull/80
 
     with ui.row():
         with ui.column():


### PR DESCRIPTION
使用 on_startup ~~似乎~~ 会阻塞进程
fastapi 会等待 on_startup 内所有函数执行完成。因此，即便检查更新是异步的，在用户体验上也是同步的。
~~这个结论仍待测试，但我建议直接回退。~~
> fastapi 会等待 on_startup 完成。目前建议禁用，后续版本再修复

考虑使用 Timer 等方式延后检查时机。