### PR TITLE
fix: No module named 'MaaDebugger.main'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 readme = "README.md"
 urls = { Homepage = "https://github.com/MaaXYZ/MaaDebugger" }
 requires-python = ">=3.9"
-scripts = { MaaDebugger = "MaaDebugger.main:main" }
+scripts = { MaaDebugger = "MaaDebugger.__main__:main" }
 
 [build-system]
 requires = ["pdm-backend"]

--- a/src/MaaDebugger/__main__.py
+++ b/src/MaaDebugger/__main__.py
@@ -1,7 +1,8 @@
 from . import MaaDebugger
 from .utils.arg_parser import ArgParser
 
-if __name__ == "__main__":
+
+def main():
     args = ArgParser()
     host = args.get_host()
     port = args.get_port()
@@ -14,3 +15,7 @@ if __name__ == "__main__":
         show=show,
         dark=dark,
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
现在同时支持`python -m MaaDebugger`和`MaaDebugger`两种启动方式