### PR TITLE
fix(mafw): 修复连接代理时未清理旧连接的问题

### DIFF
--- a/src/MaaDebugger/maafw/__init__.py
+++ b/src/MaaDebugger/maafw/__init__.py
@@ -147,6 +147,10 @@ class MaaFW:
 
     @asyncify
     def connect_agent(self, identifier: Optional[str]) -> Tuple[bool, Optional[str]]:
+        # 连接时，若有旧的连接，清理旧的连接
+        if self.agent:
+            self.agent = None
+        
         if agent := self.create_agent(identifier):
             self.agent = agent
             self.agent_identifier = agent.identifier

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -418,10 +418,9 @@ def agent_control():
     async def on_click_agent():
         GlobalStatus.agent_connecting = Status.RUNNING
 
-        await maafw.connect_agent(agent_identifier_input.value)
-        agent_identifier_input.value = maafw.agent_identifier
-
         connected, error = await maafw.connect_agent(agent_identifier_input.value)
+        agent_identifier_input.value = maafw.agent_identifier
+        
         if not connected:
             GlobalStatus.agent_connecting = Status.FAILED
             ui.notify(error, position="bottom-right", type="negative")


### PR DESCRIPTION
- 在connect_agent方法中添加清理旧连接的逻辑
- 确保在创建新代理前将旧代理设置为None

## Summary by Sourcery

确保在建立新的代理连接之前重置代理连接，以避免使用过期的连接。

Bug Fixes:
- 在连接时，在创建并分配新的代理客户端之前，清除任何现有的代理连接实例。
- 调整代理连接处理程序，使其依赖单次连接调用，并仅在成功获得连接结果后更新显示的代理标识符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure agent connections are reset before establishing a new agent connection to avoid using stale connections.

Bug Fixes:
- Clear any existing agent connection instance before creating and assigning a new agent client when connecting.
- Adjust the agent connection handler to rely on a single connect call and update the displayed agent identifier only after a successful connection result.

</details>