### PR TITLE
fix(mafw): 修复代理连接管理问题

### DIFF
--- a/src/MaaDebugger/maafw/__init__.py
+++ b/src/MaaDebugger/maafw/__init__.py
@@ -145,8 +145,18 @@ class MaaFW:
 
         return agent
 
+    def clean_agent(self):
+        if self.agent:
+            # 不使用 self.agent.disconnect() 方法进行断开连接
+            # 因为该方法会导致后续 agent 无法连接
+            self.agent = None
+            self.agent_identifier = None
+
     @asyncify
     def connect_agent(self, identifier: Optional[str]) -> Tuple[bool, Optional[str]]:
+        # 连接时，若有旧的连接，清理旧的连接
+        self.clean_agent()
+
         if agent := self.create_agent(identifier):
             self.agent = agent
             self.agent_identifier = agent.identifier

--- a/src/MaaDebugger/webpage/index_page/master_control.py
+++ b/src/MaaDebugger/webpage/index_page/master_control.py
@@ -418,12 +418,10 @@ def agent_control():
     async def on_click_agent():
         GlobalStatus.agent_connecting = Status.RUNNING
 
-        await maafw.connect_agent(agent_identifier_input.value)
-        agent_identifier_input.value = maafw.agent_identifier
-
         connected, error = await maafw.connect_agent(agent_identifier_input.value)
         if not connected:
             GlobalStatus.agent_connecting = Status.FAILED
+            agent_identifier_input.value = maafw.agent_identifier
             ui.notify(error, position="bottom-right", type="negative")
             print(error)
             return


### PR DESCRIPTION
- 添加了 clean_agent 方法用于清理旧的 agent 连接
- 在连接新 agent 时自动清理旧连接避免冲突

## Summary by Sourcery

确保在建立新连接之前清理代理连接，以防止冲突。

Bug 修复：
- 在连接新代理之前清除现有的代理引用，以避免框架中的连接冲突和状态过期问题。
- 调整代理连接的 UI 流程，使代理标识符输入仅在连接尝试成功后才被更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure agent connections are cleaned up before establishing a new connection to prevent conflicts.

Bug Fixes:
- Clear existing agent references before connecting a new agent to avoid connection conflicts and stale state in the framework.
- Adjust the agent connection UI flow so the agent identifier input is only updated after a successful connection attempt.

</details>