### PR TITLE
perf: 复用 AsyncClient 替代 ThreadPoolExecutor 避免 SSL 上下文阻塞

### DIFF
--- a/src/MaaDebugger/utils/update_checker/check.py
+++ b/src/MaaDebugger/utils/update_checker/check.py
@@ -53,7 +53,6 @@ async def check_update() -> Union[CheckStatus, str, None]:
         return CheckStatus.SKIPPED
     elif "FAILED" in (__version__.tag_name, __version__.version):
         return CheckStatus.FAILED
-
     else:
         vers = await asyncio.gather(
             _get_from_pypi(PYPI_API),


### PR DESCRIPTION
fix: (MaaXYZ/MaaDebugger#160)

## Summary by Sourcery

增强功能：
- 将基于 `ThreadPoolExecutor` 的同步 HTTP 调用替换为可复用的 `httpx.AsyncClient`，以实现对 PyPI 版本的非阻塞检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace ThreadPoolExecutor-based synchronous HTTP calls with a reusable httpx.AsyncClient for non-blocking PyPI version checks.

</details>