### PR TITLE
ci: npm nightly

### DIFF
--- a/.github/actions/publish_nodejs/action.yml
+++ b/.github/actions/publish_nodejs/action.yml
@@ -1,0 +1,105 @@
+name: publish nodejs package
+description: publish nodejs package
+inputs:
+    token:
+        description: The NPM access token to use when publishing
+        required: false
+    access:
+        description: >
+            Determines whether the published package should be publicly visible,
+            or restricted to members of your NPM organization.
+        required: false
+    path:
+        description: The path to the package directory.
+        required: false
+        default: "."
+    tag:
+        description: The tag to use when publishing the package.
+        required: false
+        default: "latest"
+    dry-run:
+        description: Run npm with the --dry-run flag to avoid actually publishing anything.
+        required: false
+    on_finished:
+        description: Run a bash on finished.
+        required: false
+    on_publish_failed:
+        description: Run a bash on publish failed.
+        required: false
+outputs:
+    failed:
+        description: "Random number"
+        value: ${{ (steps.nodejs.outputs.id == '' || steps.publish_failed.outputs.failed == 'true') && 'true' || '' }}
+
+runs:
+    using: "composite"
+    steps:
+        - uses: actions/setup-node@v5
+          with:
+              node-version: "24"
+        - uses: JS-DevTools/npm-publish@v4
+          id: nodejs
+          with:
+              package: ${{ inputs.path }}/maa-debugger
+              tag: ${{ inputs.tag }}
+              token: ${{ inputs.token }}
+              access: ${{ inputs.access }}
+              dry-run: ${{ inputs.dry-run }}
+        - uses: JS-DevTools/npm-publish@v4
+          with:
+              package: ${{ inputs.path }}/maa-debugger-win32-x64
+              tag: ${{ inputs.tag }}
+              token: ${{ inputs.token }}
+              access: ${{ inputs.access }}
+              dry-run: ${{ inputs.dry-run }}
+        - uses: JS-DevTools/npm-publish@v4
+          with:
+              package: ${{ inputs.path }}/maa-debugger-win32-arm64
+              tag: ${{ inputs.tag }}
+              token: ${{ inputs.token }}
+              access: ${{ inputs.access }}
+              dry-run: ${{ inputs.dry-run }}
+        - uses: JS-DevTools/npm-publish@v4
+          with:
+              package: ${{ inputs.path }}/maa-debugger-linux-x64
+              tag: ${{ inputs.tag }}
+              token: ${{ inputs.token }}
+              access: ${{ inputs.access }}
+              dry-run: ${{ inputs.dry-run }}
+        - uses: JS-DevTools/npm-publish@v4
+          with:
+              package: ${{ inputs.path }}/maa-debugger-linux-arm64
+              tag: ${{ inputs.tag }}
+              token: ${{ inputs.token }}
+              access: ${{ inputs.access }}
+              dry-run: ${{ inputs.dry-run }}
+        - uses: JS-DevTools/npm-publish@v4
+          with:
+              package: ${{ inputs.path }}/maa-debugger-darwin-x64
+              tag: ${{ inputs.tag }}
+              token: ${{ inputs.token }}
+              access: ${{ inputs.access }}
+              dry-run: ${{ inputs.dry-run }}
+        - uses: JS-DevTools/npm-publish@v4
+          with:
+              package: ${{ inputs.path }}/maa-debugger-darwin-arm64
+              tag: ${{ inputs.tag }}
+              token: ${{ inputs.token }}
+              access: ${{ inputs.access }}
+              dry-run: ${{ inputs.dry-run }}
+        - name: Finished
+          if: always()
+          shell: bash
+          run: |
+              eval $ON_FINISHED || echo "::warning::Failed to eval $ON_FINISHED"
+          env:
+              ON_FINISHED: ${{ inputs.on_finished }}
+        - name: Publish Failed
+          id: publish_failed
+          if: failure() || steps.nodejs.outputs.id == ''
+          shell: bash
+          run: |
+              eval $ON_PUBLISH_FAILED || echo "::warning::Failed to eval $ON_PUBLISH_FAILED"
+              echo "failed=true" >> $GITHUB_OUTPUT
+          env:
+              ON_PUBLISH_FAILED: ${{ inputs.on_publish_failed }}

--- a/.github/scripts/prepare-npm-package.mjs
+++ b/.github/scripts/prepare-npm-package.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function getRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function getReleaseChannel() {
+  return process.env.RELEASE_CHANNEL || "nightly";
+}
+
+function getPackageVersion(channel) {
+  if (channel === "nightly") {
+    const sha = (process.env.GITHUB_SHA || "dev").slice(0, 7);
+    const runNumber = process.env.GITHUB_RUN_NUMBER || "0";
+    const runAttempt = process.env.GITHUB_RUN_ATTEMPT || "1";
+    return `0.0.0-nightly.${runNumber}.${runAttempt}.${sha}`;
+  }
+
+  if (channel === "latest") {
+    return getRequiredEnv("RELEASE_VERSION");
+  }
+
+  throw new Error(`Unsupported RELEASE_CHANNEL: ${channel}`);
+}
+
+function buildPublishConfig(channel) {
+  return {
+    access: "public",
+    provenance: true,
+    tag: channel,
+  };
+}
+
+function main() {
+  const packagePath = path.resolve(getRequiredEnv("PACKAGE_JSON_PATH"));
+  const packageName = process.env.PACKAGE_NAME;
+  const targetOS = process.env.TARGET_OS;
+  const targetCPU = process.env.TARGET_CPU;
+  const channel = getReleaseChannel();
+
+  const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  const version = getPackageVersion(channel);
+
+  if (packageName) {
+    pkg.name = packageName;
+  }
+
+  pkg.version = version;
+  pkg.publishConfig = buildPublishConfig(channel);
+
+  if (targetOS) {
+    pkg.os = [targetOS];
+  }
+
+  if (targetCPU) {
+    pkg.cpu = [targetCPU];
+  }
+
+  if (pkg.optionalDependencies) {
+    for (const key of Object.keys(pkg.optionalDependencies)) {
+      pkg.optionalDependencies[key] = version;
+    }
+  }
+
+  fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+main();

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - "rft/nodejs"
-    paths:
-      - ".github/workflows/**"
-      - "build.mjs"
-      - "publish/dependence.txt"
-      - "server/**"
-      - "web/**"
-
   workflow_dispatch:
 
   workflow_call:
@@ -53,6 +43,7 @@ jobs:
   build:
     needs: build-frontend
     strategy:
+      fail-fast: false
       matrix:
         include:
           - goos: windows
@@ -155,6 +146,7 @@ jobs:
 
           cp "MaaDebugger${{ matrix.ext }}" "${ARTIFACT_NAME}/"
           cp -r maafw_dl/bin/* "${ARTIFACT_NAME}/bin/"
+          cp README.md LICENSE "${ARTIFACT_NAME}/"
 
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/npm-nightly.yml
+++ b/.github/workflows/npm-nightly.yml
@@ -33,32 +33,32 @@ jobs:
       matrix:
         include:
           - artifact_name: MaaDebugger-win-x86_64
-            package_name: maa-debugger-win32-x64
+            package_name: "@weinibuliu/maa-debugger-win32-x64"
             os: win32
             cpu: x64
             bin_name: MaaDebugger.exe
           - artifact_name: MaaDebugger-win-aarch64
-            package_name: maa-debugger-win32-arm64
+            package_name: "@weinibuliu/maa-debugger-win32-arm64"
             os: win32
             cpu: arm64
             bin_name: MaaDebugger.exe
           - artifact_name: MaaDebugger-linux-x86_64
-            package_name: maa-debugger-linux-x64
+            package_name: "@weinibuliu/maa-debugger-linux-x64"
             os: linux
             cpu: x64
             bin_name: MaaDebugger
           - artifact_name: MaaDebugger-linux-aarch64
-            package_name: maa-debugger-linux-arm64
+            package_name: "@weinibuliu/maa-debugger-linux-arm64"
             os: linux
             cpu: arm64
             bin_name: MaaDebugger
           - artifact_name: MaaDebugger-macos-x86_64
-            package_name: maa-debugger-darwin-x64
+            package_name: "@weinibuliu/maa-debugger-darwin-x64"
             os: darwin
             cpu: x64
             bin_name: MaaDebugger
           - artifact_name: MaaDebugger-macos-aarch64
-            package_name: maa-debugger-darwin-arm64
+            package_name: "@weinibuliu/maa-debugger-darwin-arm64"
             os: darwin
             cpu: arm64
             bin_name: MaaDebugger
@@ -110,7 +110,8 @@ jobs:
           cp publish/npm/index.js dist/main/index.js
           cp README.md LICENSE dist/main/
 
-          node -e "const fs=require('node:fs'); const path=require('node:path'); const packagePath=path.resolve('dist/main/package.json'); const pkg=JSON.parse(fs.readFileSync(packagePath,'utf8')); const sha=(process.env.GITHUB_SHA||'dev').slice(0,7); const runNumber=process.env.GITHUB_RUN_NUMBER||'0'; const runAttempt=process.env.GITHUB_RUN_ATTEMPT||'1'; const version=`0.0.0-nightly.${runNumber}.${runAttempt}.${sha}`; pkg.version=version; pkg.publishConfig={access:'public', provenance:true, tag:'nightly'}; if (pkg.optionalDependencies) { for (const key of Object.keys(pkg.optionalDependencies)) { pkg.optionalDependencies[key]=version; } } fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2)+'\n');"
+          PACKAGE_JSON_PATH="dist/main/package.json" \
+          node .github/scripts/prepare-npm-package.mjs
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/npm-nightly.yml
+++ b/.github/workflows/npm-nightly.yml
@@ -1,0 +1,133 @@
+name: npm Nightly
+
+on:
+  push:
+    branches:
+      - "rft/nodejs"
+    tags-ignore:
+      - "**"
+    paths:
+      - ".github/workflows/**"
+      - "build.mjs"
+      - "publish/**"
+      - "server/**"
+      - "web/**"
+      - "README.md"
+      - "LICENSE"
+  workflow_dispatch:
+
+concurrency:
+  group: npm-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  publish-platform-nightly:
+    name: Publish ${{ matrix.package_name }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact_name: MaaDebugger-win-x86_64
+            package_name: maa-debugger-win32-x64
+            os: win32
+            cpu: x64
+            bin_name: MaaDebugger.exe
+          - artifact_name: MaaDebugger-win-aarch64
+            package_name: maa-debugger-win32-arm64
+            os: win32
+            cpu: arm64
+            bin_name: MaaDebugger.exe
+          - artifact_name: MaaDebugger-linux-x86_64
+            package_name: maa-debugger-linux-x64
+            os: linux
+            cpu: x64
+            bin_name: MaaDebugger
+          - artifact_name: MaaDebugger-linux-aarch64
+            package_name: maa-debugger-linux-arm64
+            os: linux
+            cpu: arm64
+            bin_name: MaaDebugger
+          - artifact_name: MaaDebugger-macos-x86_64
+            package_name: maa-debugger-darwin-x64
+            os: darwin
+            cpu: x64
+            bin_name: MaaDebugger
+          - artifact_name: MaaDebugger-macos-aarch64
+            package_name: maa-debugger-darwin-arm64
+            os: darwin
+            cpu: arm64
+            bin_name: MaaDebugger
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: .artifacts/platform
+
+      - name: Prepare platform nightly package
+        shell: bash
+        run: |
+          rm -rf dist/platform
+          mkdir -p dist/platform
+
+          cp publish/npm/platform-package.json dist/platform/package.json
+          cp README.md LICENSE dist/platform/
+          cp ".artifacts/platform/${{ matrix.bin_name }}" "dist/platform/${{ matrix.bin_name }}"
+
+          PACKAGE_NAME="${{ matrix.package_name }}" \
+          TARGET_OS="${{ matrix.os }}" \
+          TARGET_CPU="${{ matrix.cpu }}" \
+          node -e "const fs=require('node:fs'); const path=require('node:path'); const packagePath=path.resolve('dist/platform/package.json'); const pkg=JSON.parse(fs.readFileSync(packagePath,'utf8')); const sha=(process.env.GITHUB_SHA||'dev').slice(0,7); const runNumber=process.env.GITHUB_RUN_NUMBER||'0'; const runAttempt=process.env.GITHUB_RUN_ATTEMPT||'1'; const version=`0.0.0-nightly.${runNumber}.${runAttempt}.${sha}`; pkg.name=process.env.PACKAGE_NAME; pkg.version=version; pkg.os=[process.env.TARGET_OS]; pkg.cpu=[process.env.TARGET_CPU]; pkg.publishConfig={access:'public', provenance:true, tag:'nightly'}; fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2)+'\n');"
+
+      - name: Publish platform nightly
+        run: npm publish ./dist/platform --tag nightly --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-main-nightly:
+    name: Publish maa-debugger
+    needs: publish-platform-nightly
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Prepare main nightly package
+        shell: bash
+        run: |
+          rm -rf dist/main
+          mkdir -p dist/main
+
+          cp publish/npm/package.json dist/main/package.json
+          cp publish/npm/index.js dist/main/index.js
+          cp README.md LICENSE dist/main/
+
+          node -e "const fs=require('node:fs'); const path=require('node:path'); const packagePath=path.resolve('dist/main/package.json'); const pkg=JSON.parse(fs.readFileSync(packagePath,'utf8')); const sha=(process.env.GITHUB_SHA||'dev').slice(0,7); const runNumber=process.env.GITHUB_RUN_NUMBER||'0'; const runAttempt=process.env.GITHUB_RUN_ATTEMPT||'1'; const version=`0.0.0-nightly.${runNumber}.${runAttempt}.${sha}`; pkg.version=version; pkg.publishConfig={access:'public', provenance:true, tag:'nightly'}; if (pkg.optionalDependencies) { for (const key of Object.keys(pkg.optionalDependencies)) { pkg.optionalDependencies[key]=version; } } fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2)+'\n');"
+
+      - name: Publish main nightly
+        run: npm publish ./dist/main --tag nightly --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-nightly.yml
+++ b/.github/workflows/npm-nightly.yml
@@ -24,13 +24,10 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
 
-  publish-platform-nightly:
-    name: Publish ${{ matrix.package_name }}
+  package-nodejs-nightly:
+    name: Package nodejs nightly
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -69,17 +66,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
       - uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.artifact_name }}
           path: .artifacts/platform
 
-      - name: Prepare platform nightly package
+      - name: Prepare nodejs nightly package
         shell: bash
         run: |
           rm -rf dist/platform
@@ -94,26 +86,19 @@ jobs:
           TARGET_CPU="${{ matrix.cpu }}" \
           node -e "const fs=require('node:fs'); const path=require('node:path'); const packagePath=path.resolve('dist/platform/package.json'); const pkg=JSON.parse(fs.readFileSync(packagePath,'utf8')); const sha=(process.env.GITHUB_SHA||'dev').slice(0,7); const runNumber=process.env.GITHUB_RUN_NUMBER||'0'; const runAttempt=process.env.GITHUB_RUN_ATTEMPT||'1'; const version=`0.0.0-nightly.${runNumber}.${runAttempt}.${sha}`; pkg.name=process.env.PACKAGE_NAME; pkg.version=version; pkg.os=[process.env.TARGET_OS]; pkg.cpu=[process.env.TARGET_CPU]; pkg.publishConfig={access:'public', provenance:true, tag:'nightly'}; fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2)+'\n');"
 
-      - name: Publish platform nightly
-        run: npm publish ./dist/platform --tag nightly --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pkgs-nodejs-${{ matrix.package_name }}
+          path: dist/platform
+          if-no-files-found: error
 
-  publish-main-nightly:
-    name: Publish maa-debugger
-    needs: publish-platform-nightly
+  package-nodejs-main-nightly:
+    name: Package maa-debugger nightly
+    needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
 
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
 
       - name: Prepare main nightly package
         shell: bash
@@ -127,7 +112,52 @@ jobs:
 
           node -e "const fs=require('node:fs'); const path=require('node:path'); const packagePath=path.resolve('dist/main/package.json'); const pkg=JSON.parse(fs.readFileSync(packagePath,'utf8')); const sha=(process.env.GITHUB_SHA||'dev').slice(0,7); const runNumber=process.env.GITHUB_RUN_NUMBER||'0'; const runAttempt=process.env.GITHUB_RUN_ATTEMPT||'1'; const version=`0.0.0-nightly.${runNumber}.${runAttempt}.${sha}`; pkg.version=version; pkg.publishConfig={access:'public', provenance:true, tag:'nightly'}; if (pkg.optionalDependencies) { for (const key of Object.keys(pkg.optionalDependencies)) { pkg.optionalDependencies[key]=version; } } fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2)+'\n');"
 
-      - name: Publish main nightly
-        run: npm publish ./dist/main --tag nightly --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pkgs-nodejs-maa-debugger
+          path: dist/main
+          if-no-files-found: error
+
+  merge-nodejs-nightly-artifacts:
+    name: Merge nodejs nightly artifacts
+    needs:
+      - package-nodejs-nightly
+      - package-nodejs-main-nightly
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: pkgs-nodejs-*
+          path: assets/pkgs-nodejs
+          merge-multiple: false
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pkgs-nodejs
+          path: assets/pkgs-nodejs
+          if-no-files-found: error
+
+  publish-nodejs-nightly:
+    name: Publish nodejs nightly
+    needs: merge-nodejs-nightly-artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: pkgs-nodejs
+          path: assets/pkgs-nodejs
+
+      - uses: ./.github/actions/publish_nodejs
+        id: publish
+        with:
+          access: public
+          path: assets/pkgs-nodejs
+          tag: nightly
+          dry-run: false
+          token: ${{ secrets.NPM_TOKEN }}

--- a/publish/npm/index.js
+++ b/publish/npm/index.js
@@ -4,7 +4,7 @@ const { spawn } = require("node:child_process");
 const { existsSync } = require("node:fs");
 const path = require("node:path");
 
-const platformPackageName = `maa-debugger-${process.platform}-${process.arch}`;
+const platformPackageName = `@weinibuliu/maa-debugger-${process.platform}-${process.arch}`;
 
 let platformPackageRoot;
 try {

--- a/publish/npm/index.js
+++ b/publish/npm/index.js
@@ -3,13 +3,27 @@
 const { spawn } = require("node:child_process");
 const { existsSync } = require("node:fs");
 const path = require("node:path");
-const { exit } = require("node:process");
 
-// 获取可执行文件路径
-const rootDir = path.resolve(__dirname);
+const platformPackageName = `maa-debugger-${process.platform}-${process.arch}`;
+
+let platformPackageRoot;
+try {
+  platformPackageRoot = path.dirname(
+    require.resolve(`${platformPackageName}/package.json`),
+  );
+} catch (error) {
+  console.error(
+    `[maa-debugger] Missing platform package: ${platformPackageName}`,
+  );
+  console.error(
+    `[maa-debugger] Reinstall the package on ${process.platform}-${process.arch} or choose a supported platform.`,
+  );
+  process.exit(1);
+}
+
 const isWindows = process.platform === "win32";
 const executableName = `MaaDebugger${isWindows ? ".exe" : ""}`;
-const exePath = path.join(rootDir, executableName);
+const exePath = path.join(platformPackageRoot, executableName);
 if (!existsSync(exePath)) {
   console.error(`[maa-debugger] Missing executable: ${exePath}`);
   console.error(
@@ -18,16 +32,13 @@ if (!existsSync(exePath)) {
   process.exit(1);
 }
 
-// 获取 MaaFramework 动态库路径
 const nodePath = path.resolve(require.resolve("@maaxyz/maa-node"), "../../../");
 const channelPath = path.join(
   nodePath,
   `maa-node-${process.platform}-${process.arch}`,
 );
 
-// 启动进程
 const child = spawn(exePath, process.argv.slice(2), {
-  // cwd: rootDir,
   stdio: "inherit",
   env: {
     ...process.env,

--- a/publish/npm/package.json
+++ b/publish/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "maa-debugger",
+  "name": "@weinibuliu/maa-debugger",
   "version": "0.0.0",
   "description": "Official desktop debugger for MaaFramework, with integrated web UI and real-time task inspection.",
   "bin": {
@@ -16,9 +16,20 @@
   "dependencies": {
     "@maaxyz/maa-node": "5.8.0-beta.1"
   },
+  "optionalDependencies": {
+    "@weinibuliu/maa-debugger-win32-x64": "0.0.0",
+    "@weinibuliu/maa-debugger-win32-arm64": "0.0.0",
+    "@weinibuliu/maa-debugger-linux-x64": "0.0.0",
+    "@weinibuliu/maa-debugger-linux-arm64": "0.0.0",
+    "@weinibuliu/maa-debugger-darwin-x64": "0.0.0",
+    "@weinibuliu/maa-debugger-darwin-arm64": "0.0.0"
+  },
   "repository": {
     "type": "github",
     "url": "git+https://github.com/MaaXYZ/MaaDebugger.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "maaframework",

--- a/publish/npm/package.json
+++ b/publish/npm/package.json
@@ -7,8 +7,6 @@
   },
   "files": [
     "index.js",
-    "MaaDebugger.exe",
-    "MaaDebugger",
     "README.md",
     "LICENSE"
   ],

--- a/publish/npm/platform-package.json
+++ b/publish/npm/platform-package.json
@@ -1,0 +1,17 @@
+{
+  "name": "maa-debugger-platform",
+  "version": "0.0.0",
+  "description": "Platform binary package for MaaDebugger.",
+  "files": ["MaaDebugger.exe", "MaaDebugger", "README.md", "LICENSE"],
+  "repository": {
+    "type": "github",
+    "url": "git+https://github.com/MaaXYZ/MaaDebugger.git"
+  },
+  "keywords": ["maaframework", "maa", "debugger", "automation", "desktop"],
+  "author": "MaaXYZ",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/MaaXYZ/MaaDebugger/issues"
+  },
+  "homepage": "https://github.com/MaaXYZ/MaaDebugger"
+}


### PR DESCRIPTION
## Summary by Sourcery

为 `maa-debugger` 引入按平台划分二进制文件的 nightly npm 发布机制，并更新 npm 入口脚本，从各平台专用包中加载可执行文件。

New Features:
- 新增 GitHub Actions 工作流，用于构建并发布带有平台特定二进制文件的 `maa-debugger` nightly npm 包，以及一个主聚合包。
- 引入平台特定 npm 包模板清单，用于按操作系统/架构分发 MaaDebugger 二进制文件。

Enhancements:
- 更新 npm 入口脚本，从平台特定包中解析并执行 MaaDebugger，当缺少平台包或可执行文件时提供更清晰的错误信息。
- 在构建产物和 npm 包中包含 README 和 LICENSE 文件，以提供更完善的分发元数据。

Build:
- 确保构建产物在打包 MaaDebugger 二进制文件时同时包含 README 和 LICENSE。

CI:
- 新增 `npm-nightly` GitHub Actions 工作流，用于构建 MaaDebugger 产物，将其打包为按平台划分的 npm 包，并带有溯源信息和标签地向 npm 发布 nightly 构建。
- 调整共享构建工作流，在构建矩阵中禁用 fail-fast，以提高多平台构建的稳定性和鲁棒性。
- 从主构建工作流中移除直接 push 触发配置，以便该工作流可以被 nightly 工作流复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce nightly npm publishing for maa-debugger with platform-specific binaries and update the npm entry script to load executables from per-platform packages.

New Features:
- Add GitHub Actions workflow to build and publish nightly platform-specific maa-debugger npm packages and a main aggregator package.
- Introduce a template platform-specific npm package manifest for distributing MaaDebugger binaries per OS/architecture.

Enhancements:
- Update npm entry script to resolve and execute MaaDebugger from platform-specific packages, with clearer errors when the platform package or executable is missing.
- Include README and LICENSE files in build artifacts and npm packages for better distribution metadata.

Build:
- Ensure build artifacts include README and LICENSE alongside MaaDebugger binaries for packaging.

CI:
- Add npm-nightly GitHub Actions workflow that builds MaaDebugger artifacts, packages them into per-platform npm packages, and publishes nightly builds to npm with provenance and tagging.
- Adjust shared build workflow to disable fail-fast in the build matrix for more resilient multi-platform builds.
- Remove direct push trigger configuration from the main build workflow so it can be reused by the nightly workflow.

</details>